### PR TITLE
fix: replace @Redirect with @WrapOperation to resolve mixin conflicts

### DIFF
--- a/src/main/java/com/pedrorok/hypertube/mixin/core/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/com/pedrorok/hypertube/mixin/core/ServerGamePacketListenerImplMixin.java
@@ -4,8 +4,9 @@ import com.pedrorok.hypertube.core.travel.TravelConstants;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import org.spongepowered.asm.mixin.Mixin;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
  * @author Rok, Pedro Lucas nmm. Created on 14/07/2025
@@ -14,15 +15,15 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(ServerGamePacketListenerImpl.class)
 public class ServerGamePacketListenerImplMixin {
 
-    @Redirect(
+    @WrapOperation(
             method = "handleMovePlayer",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/level/ServerPlayer;isChangingDimension()Z"
             )
     )
-    private boolean redirectIsChangingDimension(ServerPlayer player) {
+    private boolean redirectIsChangingDimension(ServerPlayer player, Operation<Boolean> original) {
         if (player.getPersistentData().getBoolean(TravelConstants.TRAVEL_TAG)) return true;
-        return player.isChangingDimension();
+        return original.call(player);
     }
 }


### PR DESCRIPTION
Change the ServerGamePacketListenerImplMixin from using exclusive @Redirect to chainable @WrapOperation, preventing injection failures when other mods (e.g. Sable) also target the same isChangingDimension() call in handleMovePlayer.