### PR TITLE
Fix for issue #142

### DIFF
--- a/src/main/java/com/pedrorok/hypertube/core/travel/TravelPathMover.java
+++ b/src/main/java/com/pedrorok/hypertube/core/travel/TravelPathMover.java
@@ -60,10 +60,9 @@ public class TravelPathMover {
         
         // If the entrance is on a virtual sub-level, the distance will be massive.
         // Snap the start position to the virtual space to avoid infinite distance tracking.
-        if (this.currentStart.distanceToSqr(this.currentEnd) > 10000) { // > 100 blocks away
+        if (this.currentStart.distanceToSqr(this.currentEnd) > 262144) { // > 512 blocks away
             this.currentStart = this.currentEnd;
         }
-        // -------------------------------
 
         this.totalDistance = currentStart.distanceTo(currentEnd);
         this.traveled = 0;
@@ -80,8 +79,6 @@ public class TravelPathMover {
             return;
         }
 
-        // Instantly process the client's finish packet instead of waiting
-        // for the current massive distance segment to naturally conclude.
         if (finished) {
             onFinishCallback.accept(entity, false);
             return;

--- a/src/main/java/com/pedrorok/hypertube/core/travel/TravelPathMover.java
+++ b/src/main/java/com/pedrorok/hypertube/core/travel/TravelPathMover.java
@@ -57,6 +57,14 @@ public class TravelPathMover {
 
         this.currentStart = entityPos;
         this.currentEnd = pathPoints.getFirst().subtract(0, 0.25, 0);
+        
+        // If the entrance is on a virtual sub-level, the distance will be massive.
+        // Snap the start position to the virtual space to avoid infinite distance tracking.
+        if (this.currentStart.distanceToSqr(this.currentEnd) > 10000) { // > 100 blocks away
+            this.currentStart = this.currentEnd;
+        }
+        // -------------------------------
+
         this.totalDistance = currentStart.distanceTo(currentEnd);
         this.traveled = 0;
 
@@ -72,9 +80,16 @@ public class TravelPathMover {
             return;
         }
 
+        // Instantly process the client's finish packet instead of waiting
+        // for the current massive distance segment to naturally conclude.
+        if (finished) {
+            onFinishCallback.accept(entity, false);
+            return;
+        }
+
         if (traveled >= totalDistance) {
             currentSegment++;
-            if (currentSegment >= pathPoints.size() || finished) {
+            if (currentSegment >= pathPoints.size()) {
                 onFinishCallback.accept(entity, false);
                 return;
             }


### PR DESCRIPTION
Tested in my game, fixes this bug: https://github.com/PedroRok/CreateHypertubes/issues/142

### The Cause
Sable uses virtual "sub-levels" located millions of blocks away from the main world to handle physics contraptions. When a player enters a tube on one of these contraptions:

1. The `TravelPathMover` calculates the initial `totalDistance` between the player's real-world position and the tube's virtual sub-level position, resulting in a massive distance.
    
2. The Client correctly snaps to the tube's virtual coordinates, finishes the travel quickly, and sends the `FinishPathPacket` to the server, which sets `finished = true`.
    
3. However, the server ignores this flag because the `if (finished)` check in `tickEntity()` was nested inside the `if (traveled >= totalDistance)` block. 
    

### The Fix
1. **Coordinate Snapping:** In the `TravelPathMover` constructor, if the distance between `currentStart` and `currentEnd` is unnaturally large (> 512 blocks), the server now snaps the start position to match the tube. 
    
2. **Un-nested Finish Check:** Moved the `if (finished)` check to the top of `tickEntity()`. The server will now immediately respect the client's finish packet and safely eject the player, preventing any logic traps.