### PR TITLE
add early return in calculateRelativeBezierPoints

### DIFF
--- a/src/main/java/com/pedrorok/hypertube/core/connection/BezierConnection.java
+++ b/src/main/java/com/pedrorok/hypertube/core/connection/BezierConnection.java
@@ -90,7 +90,8 @@ public class BezierConnection implements IConnection {
 
     private List<Vec3> calculateRelativeBezierPoints() {
         if (toPos == null) return List.of();
-
+        if (distance() >= MAX_REASONABLE_DISTANCE) return List.of();
+        
         // Calculate offset between from and to positions
         BlockPos storedFromPos = fromPos.pos();
         BlockPos storedToPos = toPos.pos();


### PR DESCRIPTION
Stops the game from hanging when trying to calculate a Bezier curve to connect two points of insane distance. 
I believe this to resolve issue #149 as in my own testing i haven't been able to actually place Hypertubes between a Sable Sublevel and the "root" level or a different Sable Sublevel.