### PR TITLE
Implement Sable compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ repositories {
     maven { url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/" } // ForgeConfigAPIPort
     maven { url = "https://maven.createmod.net" } // Create, Ponder, Flywheel
     maven { url = "https://mvn.devos.one/snapshots" } // Registrate
+    maven { url = "https://maven.ryanhcode.dev/releases" } // Sable
 
 }
 
@@ -92,10 +93,10 @@ dependencies {
 
     compileOnly("curse.maven:betterthirdperson-435044:5833474")
 
-    compileOnly("maven.modrinth:create-aeronautics:1sv6OtSz")
-    runtimeOnly("maven.modrinth:create-aeronautics:1sv6OtSz")
-    compileOnly("maven.modrinth:sable:g8CObHcP")
-    runtimeOnly("maven.modrinth:sable:g8CObHcP")
+    // Sable
+    api("dev.ryanhcode.sable:sable-neoforge-${minecraft_version}:${sable_version}") {
+        exclude group: "foundry.veil"
+    }
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,3 @@ registrate_version = MC1.21-1.3.0+62
 
 # Sable
 sable_version=1.2.2
-sable_version_range=1.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,7 @@ create_version = 6.0.10-281
 ponder_version = 1.0.82
 flywheel_version = 1.0.6
 registrate_version = MC1.21-1.3.0+62
+
+# Sable
+sable_version=1.2.2
+sable_version_range=1.2.0

--- a/src/main/java/com/pedrorok/hypertube/blocks/blockentities/HyperEntranceBlockEntity.java
+++ b/src/main/java/com/pedrorok/hypertube/blocks/blockentities/HyperEntranceBlockEntity.java
@@ -109,7 +109,7 @@ public class HyperEntranceBlockEntity extends ActionTubeBlockEntity implements I
             return;
         }
 
-        TravelManager.tryStartTravel(inRangeEntity, pos, state, TubeUtils.calculateTravelSpeed(actualSpeed));
+        TravelManager.tryStartTravel(inRangeEntity, this, TubeUtils.calculateTravelSpeed(actualSpeed));
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/pedrorok/hypertube/core/compat/Mods.java
+++ b/src/main/java/com/pedrorok/hypertube/core/compat/Mods.java
@@ -10,6 +10,7 @@ import net.neoforged.fml.loading.LoadingModList;
 
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.function.Function;
 
 public enum Mods {
 	SABLE;
@@ -78,5 +79,19 @@ public enum Mods {
 		if (isLoaded()) {
 			toExecute.get().run();
 		}
+	}
+
+	/**
+	 * Simple hook to execute code if a mod is installed
+	 *
+	 * @param toExecute will be executed only if the mod is loaded
+	 * @param parameter will be passed into the scope, or returned if the mod isn't loaded
+	 * @return parameter if the mod is not loaded, otherwise the return value of the given function
+	 */
+	public <T> T executeIfInstalled(Supplier<Function<T, T>> toExecute, T parameter) {
+		if (isLoaded()) {
+			return toExecute.get().apply(parameter);
+		}
+		return parameter;
 	}
 }

--- a/src/main/java/com/pedrorok/hypertube/core/compat/sable/SableCompat.java
+++ b/src/main/java/com/pedrorok/hypertube/core/compat/sable/SableCompat.java
@@ -1,0 +1,87 @@
+package com.pedrorok.hypertube.core.compat.sable;
+
+import com.mojang.datafixers.util.Pair;
+import dev.ryanhcode.sable.Sable;
+import dev.ryanhcode.sable.sublevel.SubLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+
+public class SableCompat {
+	public static Pair<Vec3, Vec3> transformToWorld(Level level, Vec3 pos, Vec3 dir) {
+		final SubLevel subLevel = Sable.HELPER.getContaining(level, pos);
+		if (subLevel != null) {
+			return Pair.of(
+				subLevel.logicalPose().transformPosition(pos),
+				subLevel.logicalPose().transformNormal(dir)
+			);
+		}
+		return Pair.of(pos, dir);
+	}
+
+	public static Vec3 transformToWorld(Level level, Vec3 pos) {
+		final SubLevel subLevel = Sable.HELPER.getContaining(level, pos);
+		if (subLevel != null) {
+			return subLevel.logicalPose().transformPosition(pos);
+		}
+		return pos;
+	}
+
+	public static Pair<Vec3, Vec3> transformToSubLevel(Level level, Vec3 pos, Vec3 dir) {
+		final SubLevel subLevel = Sable.HELPER.getContaining(level, pos);
+		if (subLevel != null) {
+			return Pair.of(
+				subLevel.logicalPose().transformPositionInverse(pos),
+				subLevel.logicalPose().transformNormalInverse(dir)
+			);
+		}
+		return Pair.of(pos, dir);
+	}
+
+	public static Vec3 transformToSubLevel(Level level, Vec3 pos) {
+		final SubLevel subLevel = Sable.HELPER.getContaining(level, pos);
+		if (subLevel != null) {
+			return subLevel.logicalPose().transformPositionInverse(pos);
+		}
+		return pos;
+	}
+	
+	public static class Client {
+		public static Pair<Vec3, Vec3> transformToWorld(Vec3 pos, Vec3 dir) {
+			final SubLevel subLevel = Sable.HELPER.getContainingClient(pos);
+			if (subLevel != null) {
+				return Pair.of(
+					subLevel.logicalPose().transformPosition(pos),
+					subLevel.logicalPose().transformNormal(dir)
+				);
+			}
+			return Pair.of(pos, dir);
+		}
+
+		public static Vec3 transformToWorld(Vec3 pos) {
+			final SubLevel subLevel = Sable.HELPER.getContainingClient(pos);
+			if (subLevel != null) {
+				return subLevel.logicalPose().transformPosition(pos);
+			}
+			return pos;
+		}
+
+		public static Pair<Vec3, Vec3> transformToSubLevel(Vec3 pos, Vec3 dir) {
+			final SubLevel subLevel = Sable.HELPER.getContainingClient(pos);
+			if (subLevel != null) {
+				return Pair.of(
+					subLevel.logicalPose().transformPositionInverse(pos),
+					subLevel.logicalPose().transformNormalInverse(dir)
+				);
+			}
+			return Pair.of(pos, dir);
+		}
+
+		public static Vec3 transformToSubLevel(Vec3 pos) {
+			final SubLevel subLevel = Sable.HELPER.getContainingClient(pos);
+			if (subLevel != null) {
+				return subLevel.logicalPose().transformPositionInverse(pos);
+			}
+			return pos;
+		}
+	}
+}

--- a/src/main/java/com/pedrorok/hypertube/core/connection/BezierConnection.java
+++ b/src/main/java/com/pedrorok/hypertube/core/connection/BezierConnection.java
@@ -90,7 +90,8 @@ public class BezierConnection implements IConnection {
 
     private List<Vec3> calculateRelativeBezierPoints() {
         if (toPos == null) return List.of();
-
+        if (distance() >= MAX_REASONABLE_DISTANCE) return List.of();
+        
         // Calculate offset between from and to positions
         BlockPos storedFromPos = fromPos.pos();
         BlockPos storedToPos = toPos.pos();

--- a/src/main/java/com/pedrorok/hypertube/core/data/DataGenerators.java
+++ b/src/main/java/com/pedrorok/hypertube/core/data/DataGenerators.java
@@ -26,7 +26,7 @@ public class DataGenerators {
         CompletableFuture<HolderLookup.Provider> lookupProvider = event.getLookupProvider();
 
         generator.addProvider(event.includeServer(), new HypertubeRecipeGen(packOutput, lookupProvider));
-        event.getGenerator().addProvider(true, HypertubeMod.get().setDataProvider(new RegistrateDataProvider(HypertubeMod.get(), HypertubeMod.MOD_ID, event)));
+        //event.getGenerator().addProvider(true, HypertubeMod.get().setDataProvider(new RegistrateDataProvider(HypertubeMod.get(), HypertubeMod.MOD_ID, event)));
 
     }
 }

--- a/src/main/java/com/pedrorok/hypertube/core/travel/ClientTravelPathMover.java
+++ b/src/main/java/com/pedrorok/hypertube/core/travel/ClientTravelPathMover.java
@@ -1,6 +1,8 @@
 package com.pedrorok.hypertube.core.travel;
 
 import com.pedrorok.hypertube.core.camera.DetachedPlayerDirController;
+import com.pedrorok.hypertube.core.compat.Mods;
+import com.pedrorok.hypertube.core.compat.sable.SableCompat;
 import com.pedrorok.hypertube.core.connection.interfaces.ITubeActionPoint;
 import com.pedrorok.hypertube.network.packets.ActionPointReachPacket;
 import com.pedrorok.hypertube.network.packets.FinishPathPacket;
@@ -71,9 +73,10 @@ public class ClientTravelPathMover {
 
 
             data.updateLogicalPosition();
-            entity.setDeltaMovement(data.getCurrentDirection());
+            Vec3 currentDirection = Mods.SABLE.executeIfInstalled(() -> (dir) -> SableCompat.Client.transformToWorld(data.getCurrentTarget(), dir).getSecond(), data.getCurrentDirection());
+            entity.setDeltaMovement(currentDirection);
             if (data.isClientPlayer())
-                handleEntityDirection(data.getCurrentDirection());
+                handleEntityDirection(currentDirection);
         }
     }
 
@@ -93,7 +96,7 @@ public class ClientTravelPathMover {
             if (entity == null || !entity.isAlive() || entity.isSpectator()) continue;
             data.handleActionPoint((LivingEntity) entity);
 
-            Vec3 renderPos = data.getRenderPosition(partialTicks);
+            Vec3 renderPos = renderPos = Mods.SABLE.executeIfInstalled(() -> (pos) -> SableCompat.Client.transformToWorld(pos), data.getRenderPosition(partialTicks));
 
             entity.moveTo(renderPos.x, renderPos.y, renderPos.z);
         }

--- a/src/main/java/com/pedrorok/hypertube/core/travel/TravelManager.java
+++ b/src/main/java/com/pedrorok/hypertube/core/travel/TravelManager.java
@@ -1,8 +1,11 @@
 package com.pedrorok.hypertube.core.travel;
 
+import com.mojang.datafixers.util.Pair;
 import com.pedrorok.hypertube.HypertubeMod;
 import com.pedrorok.hypertube.blocks.HyperEntranceBlock;
 import com.pedrorok.hypertube.config.ClientConfig;
+import com.pedrorok.hypertube.core.compat.Mods;
+import com.pedrorok.hypertube.core.compat.sable.SableCompat;
 import com.pedrorok.hypertube.core.sound.TubeSoundManager;
 import com.pedrorok.hypertube.events.PlayerSyncEvents;
 import com.pedrorok.hypertube.network.packets.MovePathPacket;
@@ -22,6 +25,7 @@ import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.RelativeMovement;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
@@ -40,7 +44,10 @@ public class TravelManager {
 
     private static final Object2ObjectArrayMap<UUID, TravelPathMover> travelDataMap = new Object2ObjectArrayMap<>();
 
-    public static void tryStartTravel(LivingEntity entity, BlockPos pos, BlockState state, float speed) {
+    public static void tryStartTravel(LivingEntity entity, BlockEntity blockEntity, float speed) {
+        BlockState state = blockEntity.getBlockState();
+        BlockPos pos = blockEntity.getBlockPos();
+
         CompoundTag entityPersistentData = entity.getPersistentData();
         if (entityPersistentData.getBoolean(TRAVEL_TAG)) return;
 
@@ -74,7 +81,7 @@ public class TravelManager {
         float finalSpeed = (speed * TravelConstants.DEFAULT_SPEED_MULTIPLIER);
 
         TravelPathMover pathMover = new TravelPathMover(
-                pos,
+                blockEntity,
                 entity.position(),
                 travelPathData.getTravelPoints(),
                 travelPathData.getActionPoints(),
@@ -135,7 +142,7 @@ public class TravelManager {
     }
 
     private static void finishTravel(LivingEntity entity, boolean forced) {
-        Level level = entity.level();
+        final Level level = entity.level();
         if (level.isClientSide) return;
         TravelPathMover pathMover = travelDataMap.get(entity.getUUID());
         travelDataMap.remove(entity.getUUID());
@@ -154,6 +161,12 @@ public class TravelManager {
         if (blockState.getBlock() instanceof HyperEntranceBlock) {
             lastBlockPos = pathMover.getLastPos().relative(blockState.getValue(HyperEntranceBlock.FACING).getOpposite()).getCenter();
         }
+
+        Pair<Vec3, Vec3> lastPosDir = Pair.of(lastBlockPos, lastDir);
+        lastPosDir = Mods.SABLE.executeIfInstalled(() -> (posDir) -> SableCompat.transformToWorld(level, posDir.getFirst(), posDir.getSecond()), lastPosDir);
+        lastBlockPos = lastPosDir.getFirst();
+        lastDir = lastPosDir.getSecond();
+
         if (!forced) {
             if (level instanceof ServerLevel) {
                 entity.teleportTo((ServerLevel) level, lastBlockPos.x, lastBlockPos.y, lastBlockPos.z, RelativeMovement.ALL, entity.getYRot(), entity.getXRot());

--- a/src/main/java/com/pedrorok/hypertube/core/travel/TravelPathMover.java
+++ b/src/main/java/com/pedrorok/hypertube/core/travel/TravelPathMover.java
@@ -2,6 +2,8 @@ package com.pedrorok.hypertube.core.travel;
 
 import com.pedrorok.hypertube.blocks.ActionTubeBlock;
 import com.pedrorok.hypertube.blocks.blockentities.ActionTubeBlockEntity;
+import com.pedrorok.hypertube.core.compat.Mods;
+import com.pedrorok.hypertube.core.compat.sable.SableCompat;
 import com.pedrorok.hypertube.core.connection.interfaces.ITubeActionPoint;
 import com.pedrorok.hypertube.network.packets.EntityTravelDirDataPacket;
 import com.pedrorok.hypertube.network.packets.SyncEntityPosPacket;
@@ -10,6 +12,7 @@ import lombok.Setter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec3;
@@ -45,24 +48,23 @@ public class TravelPathMover {
 
     private Vec3 lastDirection;
 
-    public TravelPathMover(BlockPos firstBlockEntrance, Vec3 entityPos, List<Vec3> points, Set<BlockPos> actionPoints, float travelSpeed, Vec3 lastDirection, BlockPos lastPos, BiConsumer<LivingEntity, Boolean> onFinishCallback) {
+    public TravelPathMover(BlockEntity entrance, Vec3 entityPos, List<Vec3> points, Set<BlockPos> actionPoints, float travelSpeed, Vec3 lastDirection, BlockPos lastPos, BiConsumer<LivingEntity, Boolean> onFinishCallback) {
         this.pathPoints = points;
         this.actionPoints = actionPoints;
         this.activeActionPoints = new HashSet<>() {{
-            add(firstBlockEntrance);
+            add(entrance.getBlockPos());
         }};
         actionPoints.add(lastPos);
         this.travelSpeed = travelSpeed;
         this.lastPos = lastPos;
-
-        this.currentStart = entityPos;
-        this.currentEnd = pathPoints.getFirst().subtract(0, 0.25, 0);
         
-        // If the entrance is on a virtual sub-level, the distance will be massive.
-        // Snap the start position to the virtual space to avoid infinite distance tracking.
-        if (this.currentStart.distanceToSqr(this.currentEnd) > 262144) { // > 512 blocks away
-            this.currentStart = this.currentEnd;
-        }
+        final Level level = entrance.getLevel();
+        final Vec3 entrancePos = entrance.getBlockPos().getCenter();
+        Vec3 entranceOffset = entityPos.subtract(Mods.SABLE.executeIfInstalled(() -> (pos) -> SableCompat.transformToWorld(level, pos), entrancePos));
+        entranceOffset = Mods.SABLE.executeIfInstalled(() -> (dir) -> SableCompat.transformToSubLevel(level, entrancePos, dir).getSecond(), entranceOffset.normalize()).scale(entranceOffset.length());
+
+        this.currentStart = entrancePos.add(entranceOffset);
+        this.currentEnd = pathPoints.getFirst().subtract(0, 0.25, 0);
 
         this.totalDistance = currentStart.distanceTo(currentEnd);
         this.traveled = 0;
@@ -109,12 +111,12 @@ public class TravelPathMover {
             }
         }
 
-        Vec3 direction = currentEnd.subtract(currentStart).normalize().scale(travelSpeed);
-        Vec3 newPos = entity.position().add(direction);
+        traveled += travelSpeed;
+        Vec3 direction = currentEnd.subtract(currentStart).normalize();
+        Vec3 newPos = currentStart.add(direction.scale(traveled));
+        newPos = Mods.SABLE.executeIfInstalled(() -> (pos) -> SableCompat.transformToWorld(entity.level(), pos), newPos);
 
         entity.moveTo(newPos.x, newPos.y, newPos.z);
-        traveled += travelSpeed;
-
         entity.resetFallDistance();
 
         handleEntityDirection(entity, direction);

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -40,7 +40,7 @@ type = "optional"
 [[dependencies.${mod_id}]]
 modId = "sable"
 type = "optional"
-versionRange = "[${sable_version_range},)"
+versionRange = "[1.2.0,)"
 ordering = "NONE"
 side = "BOTH"
 

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -37,6 +37,13 @@ side="BOTH"
 modId = "betterthirdperson"
 type = "optional"
 
+[[dependencies.${mod_id}]]
+modId = "sable"
+type = "optional"
+versionRange = "[${sable_version_range},)"
+ordering = "NONE"
+side = "BOTH"
+
 
 
 # Features are specific properties of the game environment, that you may want to declare you require. This example declares


### PR DESCRIPTION
When Sable is installed, movement through Hypertubes checks to see if said Hypertube is contained within a Sable sublevel, and if so applies Sable's helper functions to obtain the "real level" position equivalent to the one in the sublevel, and then uses that position instead. In this way all movement is kept in the "real level" and not the sublevel, meaning entities never actually get teleported to the sublevel and instead just follow along with the Hypertube's twists and turns remotely.

https://github.com/user-attachments/assets/f6d95dc8-2c4c-4ad5-bb47-f94caa0d6e30

---
Fixes #148 

Includes PR #152, as it works well for preventing crashes when attempting to build a Hypertube between a Sable sublevel and "real level" (Fixes #149)

Removed use of `CreateRegistrate.setDataProvider`, as this function no longer exists (Removed in https://github.com/Creators-of-Create/Create/commit/5b01cd0a5f6ef680316882947134e328329cfc77), it was a way to access Registrate's internals instead of using the intended methods. Now when you use `CreateRegistrate.registerEventListeners`, the proper process is followed and Registrate is able to assign the data provider by itself.
For verification, here's the execution path from where `CreateRegistrate.registerEventListeners` is called within CreateHypertubes to where Registrate assigns the data provider itself:
1. https://github.com/PedroRok/CreateHypertubes/blob/ver/1.21.1/src/main/java/com/pedrorok/hypertube/HypertubeMod.java#L37
2. https://github.com/Creators-of-Create/Create/blob/d8d9086b09e55b3353c5a2d926fd38403c154553/src/main/java/com/simibubi/create/foundation/data/CreateRegistrate.java#L109
3. https://github.com/tterrag1098/Registrate/blob/3a9795ce53e5dc6471ba6310735544e157e3391e/src/main/java/com/tterrag/registrate/AbstractRegistrate.java#L207
4. https://github.com/tterrag1098/Registrate/blob/3a9795ce53e5dc6471ba6310735544e157e3391e/src/main/java/com/tterrag/registrate/AbstractRegistrate.java#L288