### PR TITLE
Improve Sable compatibility 

### DIFF
--- a/src/main/java/com/pedrorok/hypertube/core/compat/sable/EntityForceTracking.java
+++ b/src/main/java/com/pedrorok/hypertube/core/compat/sable/EntityForceTracking.java
@@ -1,0 +1,7 @@
+package com.pedrorok.hypertube.core.compat.sable;
+
+import dev.ryanhcode.sable.sublevel.SubLevel;
+
+public interface EntityForceTracking {
+    public void createHypertube$setForceTrackSubLevel(SubLevel subLevel);
+}

--- a/src/main/java/com/pedrorok/hypertube/core/compat/sable/SableCompat.java
+++ b/src/main/java/com/pedrorok/hypertube/core/compat/sable/SableCompat.java
@@ -1,87 +1,122 @@
 package com.pedrorok.hypertube.core.compat.sable;
 
+import com.pedrorok.hypertube.core.compat.sable.EntityForceTracking;
+import com.pedrorok.hypertube.HypertubeMod;
 import com.mojang.datafixers.util.Pair;
 import dev.ryanhcode.sable.Sable;
+import dev.ryanhcode.sable.api.entity.EntitySubLevelUtil;
+import dev.ryanhcode.sable.mixinterface.entity.entities_stick_sublevels.EntityStickExtension;
+import dev.ryanhcode.sable.mixinterface.entity.entity_sublevel_collision.EntityMovementExtension;
 import dev.ryanhcode.sable.sublevel.SubLevel;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 
 public class SableCompat {
-	public static Pair<Vec3, Vec3> transformToWorld(Level level, Vec3 pos, Vec3 dir) {
-		final SubLevel subLevel = Sable.HELPER.getContaining(level, pos);
-		if (subLevel != null) {
-			return Pair.of(
-				subLevel.logicalPose().transformPosition(pos),
-				subLevel.logicalPose().transformNormal(dir)
-			);
-		}
-		return Pair.of(pos, dir);
-	}
+    public static Pair<Vec3, Vec3> transformToWorld(Level level, Vec3 pos, Vec3 dir, boolean useLastPose) {
+        final SubLevel subLevel = Sable.HELPER.getContaining(level, pos);
+        if (subLevel != null) {
+            return Pair.of(
+                (useLastPose ? subLevel.lastPose() : subLevel.logicalPose()).transformPosition(pos),
+                (useLastPose ? subLevel.lastPose() : subLevel.logicalPose()).transformNormal(dir)
+            );
+        }
+        return Pair.of(pos, dir);
+    }
 
-	public static Vec3 transformToWorld(Level level, Vec3 pos) {
-		final SubLevel subLevel = Sable.HELPER.getContaining(level, pos);
-		if (subLevel != null) {
-			return subLevel.logicalPose().transformPosition(pos);
-		}
-		return pos;
-	}
+    public static Pair<Vec3, Vec3> transformToWorld(Level level, Vec3 pos, Vec3 dir) {
+        return transformToWorld(level, pos, dir, false)
+    }
 
-	public static Pair<Vec3, Vec3> transformToSubLevel(Level level, Vec3 pos, Vec3 dir) {
-		final SubLevel subLevel = Sable.HELPER.getContaining(level, pos);
-		if (subLevel != null) {
-			return Pair.of(
-				subLevel.logicalPose().transformPositionInverse(pos),
-				subLevel.logicalPose().transformNormalInverse(dir)
-			);
-		}
-		return Pair.of(pos, dir);
-	}
+    public static Vec3 transformToWorld(Level level, Vec3 pos, boolean useLastPose) {
+        return transformToWorld(level, pos, Vec3.ZERO, useLastPose).getFirst();
+    }
 
-	public static Vec3 transformToSubLevel(Level level, Vec3 pos) {
-		final SubLevel subLevel = Sable.HELPER.getContaining(level, pos);
-		if (subLevel != null) {
-			return subLevel.logicalPose().transformPositionInverse(pos);
-		}
-		return pos;
-	}
-	
-	public static class Client {
-		public static Pair<Vec3, Vec3> transformToWorld(Vec3 pos, Vec3 dir) {
-			final SubLevel subLevel = Sable.HELPER.getContainingClient(pos);
-			if (subLevel != null) {
-				return Pair.of(
-					subLevel.logicalPose().transformPosition(pos),
-					subLevel.logicalPose().transformNormal(dir)
-				);
-			}
-			return Pair.of(pos, dir);
-		}
+    public static Vec3 transformToWorld(Level level, Vec3 pos) {
+        return transformToWorld(level, pos, false);
+    }
 
-		public static Vec3 transformToWorld(Vec3 pos) {
-			final SubLevel subLevel = Sable.HELPER.getContainingClient(pos);
-			if (subLevel != null) {
-				return subLevel.logicalPose().transformPosition(pos);
-			}
-			return pos;
-		}
+    public static Pair<Vec3, Vec3> transformToSubLevel(Level level, Vec3 sublevelPos, Vec3 pos, Vec3 dir, boolean useLastPose) {
+        final SubLevel subLevel = Sable.HELPER.getContaining(level, sublevelPos);
+        if (subLevel != null) {
+            return Pair.of(
+                (useLastPose ? subLevel.lastPose() : subLevel.logicalPose()).transformPositionInverse(pos),
+                (useLastPose ? subLevel.lastPose() : subLevel.logicalPose()).transformNormalInverse(dir)
+            );
+        }
+        return Pair.of(pos, dir);
+    }
 
-		public static Pair<Vec3, Vec3> transformToSubLevel(Vec3 pos, Vec3 dir) {
-			final SubLevel subLevel = Sable.HELPER.getContainingClient(pos);
-			if (subLevel != null) {
-				return Pair.of(
-					subLevel.logicalPose().transformPositionInverse(pos),
-					subLevel.logicalPose().transformNormalInverse(dir)
-				);
-			}
-			return Pair.of(pos, dir);
-		}
+    public static Pair<Vec3, Vec3> transformToSubLevel(Level level, Vec3 sublevelPos, Vec3 pos, Vec3 dir) {
+        return transformToSubLevel(level, sublevelPos, pos, dir, false)
+    }
 
-		public static Vec3 transformToSubLevel(Vec3 pos) {
-			final SubLevel subLevel = Sable.HELPER.getContainingClient(pos);
-			if (subLevel != null) {
-				return subLevel.logicalPose().transformPositionInverse(pos);
-			}
-			return pos;
-		}
-	}
+    public static Vec3 transformToSubLevel(Level level, Vec3 sublevelPos, Vec3 pos, boolean useLastPose) {
+        return transformToSubLevel(level, sublevelPos, pos, Vec3.ZERO, useLastPose).getFirst();
+    }
+
+    public static Vec3 transformToSubLevel(Level level, Vec3 sublevelPos, Vec3 pos) {
+        return transformToSubLevel(level, sublevelPos, pos, false);
+    }
+    
+    public static void stickToSubLevel(Entity entity, Vec3 pos) {
+        if (entity instanceof final EntityForceTracking trackEntity) {
+            if (pos != null) {
+                final SubLevel subLevel = Sable.HELPER.getContaining(entity.level(), pos);
+                if (subLevel != null) {
+                    trackEntity.createHypertube$setForceTrackSubLevel(subLevel);
+                    return;
+                }
+            }
+            trackEntity.createHypertube$setForceTrackSubLevel(null);
+        }
+    }
+    
+    public static class Client {
+        public static Pair<Vec3, Vec3> transformToWorld(Vec3 pos, Vec3 dir, boolean useLastPose) {
+            final SubLevel subLevel = Sable.HELPER.getContainingClient(pos);
+            if (subLevel != null) {
+                return Pair.of(
+                    (useLastPose ? subLevel.lastPose() : subLevel.logicalPose()).transformPosition(pos),
+                    (useLastPose ? subLevel.lastPose() : subLevel.logicalPose()).transformNormal(dir)
+                );
+            }
+            return Pair.of(pos, dir);
+        }
+
+        public static Pair<Vec3, Vec3> transformToWorld(Vec3 pos, Vec3 dir) {
+            return transformToWorld(pos, dir, false)
+        }
+
+        public static Vec3 transformToWorld(Vec3 pos, boolean useLastPose) {
+            return transformToWorld(pos, Vec3.ZERO, useLastPose).getFirst();
+        }
+
+        public static Vec3 transformToWorld(Vec3 pos) {
+            return transformToWorld(pos, false);
+        }
+
+        public static Pair<Vec3, Vec3> transformToSubLevel(Vec3 sublevelPos, Vec3 pos, Vec3 dir, boolean useLastPose) {
+            final SubLevel subLevel = Sable.HELPER.getContainingClient(sublevelPos);
+            if (subLevel != null) {
+                return Pair.of(
+                    (useLastPose ? subLevel.lastPose() : subLevel.logicalPose()).transformPositionInverse(pos),
+                    (useLastPose ? subLevel.lastPose() : subLevel.logicalPose()).transformNormalInverse(dir)
+                );
+            }
+            return Pair.of(pos, dir);
+        }
+
+        public static Pair<Vec3, Vec3> transformToSubLevel(Vec3 sublevelPos, Vec3 pos, Vec3 dir) {
+            return transformToSubLevel(sublevelPos, pos, dir, false)
+        }
+
+        public static Vec3 transformToSubLevel(Vec3 sublevelPos, Vec3 pos, boolean useLastPose) {
+            return transformToSubLevel(sublevelPos, pos, Vec3.ZERO, useLastPose).getFirst();
+        }
+
+        public static Vec3 transformToSubLevel(Vec3 sublevelPos, Vec3 pos) {
+            return transformToSubLevel(sublevelPos, pos, false);
+        }
+    }
 }

--- a/src/main/java/com/pedrorok/hypertube/core/compat/sable/SableCompat.java
+++ b/src/main/java/com/pedrorok/hypertube/core/compat/sable/SableCompat.java
@@ -25,7 +25,7 @@ public class SableCompat {
     }
 
     public static Pair<Vec3, Vec3> transformToWorld(Level level, Vec3 pos, Vec3 dir) {
-        return transformToWorld(level, pos, dir, false)
+        return transformToWorld(level, pos, dir, false);
     }
 
     public static Vec3 transformToWorld(Level level, Vec3 pos, boolean useLastPose) {
@@ -48,7 +48,7 @@ public class SableCompat {
     }
 
     public static Pair<Vec3, Vec3> transformToSubLevel(Level level, Vec3 sublevelPos, Vec3 pos, Vec3 dir) {
-        return transformToSubLevel(level, sublevelPos, pos, dir, false)
+        return transformToSubLevel(level, sublevelPos, pos, dir, false);
     }
 
     public static Vec3 transformToSubLevel(Level level, Vec3 sublevelPos, Vec3 pos, boolean useLastPose) {
@@ -85,7 +85,7 @@ public class SableCompat {
         }
 
         public static Pair<Vec3, Vec3> transformToWorld(Vec3 pos, Vec3 dir) {
-            return transformToWorld(pos, dir, false)
+            return transformToWorld(pos, dir, false);
         }
 
         public static Vec3 transformToWorld(Vec3 pos, boolean useLastPose) {
@@ -108,7 +108,7 @@ public class SableCompat {
         }
 
         public static Pair<Vec3, Vec3> transformToSubLevel(Vec3 sublevelPos, Vec3 pos, Vec3 dir) {
-            return transformToSubLevel(sublevelPos, pos, dir, false)
+            return transformToSubLevel(sublevelPos, pos, dir, false);
         }
 
         public static Vec3 transformToSubLevel(Vec3 sublevelPos, Vec3 pos, boolean useLastPose) {

--- a/src/main/java/com/pedrorok/hypertube/core/travel/ClientTravelPathMover.java
+++ b/src/main/java/com/pedrorok/hypertube/core/travel/ClientTravelPathMover.java
@@ -1,5 +1,6 @@
 package com.pedrorok.hypertube.core.travel;
 
+import com.mojang.datafixers.util.Pair;
 import com.pedrorok.hypertube.core.camera.DetachedPlayerDirController;
 import com.pedrorok.hypertube.core.compat.Mods;
 import com.pedrorok.hypertube.core.compat.sable.SableCompat;
@@ -185,10 +186,11 @@ public class ClientTravelPathMover {
             }
 
             traveled += travelSpeed;
-            Pair<Vec3, Vec3> newPosDir = Pair.of(currentStart.add(direction.scale(traveled)), getCurrentDirection());
-            newPosDir = Mods.SABLE.executeIfInstalled(() -> (pos) -> SableCompat.Client.transformToWorld(newPosDir.getFirst(), newPosDir.getSecond()), newPosDir);
+            Vec3 direction = getCurrentDirection();
+            Pair<Vec3, Vec3> newPosDir = Pair.of(currentStart.add(direction.scale(traveled)), direction);
+            newPosDir = Mods.SABLE.executeIfInstalled(() -> (posDir) -> SableCompat.Client.transformToWorld(posDir.getFirst(), posDir.getSecond()), newPosDir);
             Vec3 newPos = newPosDir.getFirst();
-            Vec3 direction = newPosDir.getSecond();
+            direction = newPosDir.getSecond();
 
             moveEntity(entity, newPos);
             if (clientPlayer)

--- a/src/main/java/com/pedrorok/hypertube/core/travel/ClientTravelPathMover.java
+++ b/src/main/java/com/pedrorok/hypertube/core/travel/ClientTravelPathMover.java
@@ -35,8 +35,13 @@ public class ClientTravelPathMover {
     private static final Int2ObjectArrayMap<PathData> ACTIVE_PATHS = new Int2ObjectArrayMap<>();
 
     public static void startMoving(MovePathPacket packet) {
-        boolean isPlayer = Minecraft.getInstance().player.getId() == packet.entityId();
-        ACTIVE_PATHS.put(packet.entityId(), new PathData(packet.pathPoints(), packet.actionPoints(), packet.travelSpeed(), isPlayer));
+        final Minecraft mc = Minecraft.getInstance();
+        final int id = packet.entityId();
+        final Entity entity = mc.level.getEntity(id);
+        final boolean isPlayer = mc.player.getId() == id;
+
+        Mods.SABLE.executeIfInstalled(() -> () -> SableCompat.stickToSubLevel(entity, packet.actionPoints().iterator().next().getCenter()));
+        ACTIVE_PATHS.put(packet.entityId(), new PathData(entity.position(), packet.pathPoints(), packet.actionPoints(), packet.travelSpeed(), isPlayer));
     }
 
     public static void updateEntitySpeed(SpeedChangePacket packet) {
@@ -60,23 +65,10 @@ public class ClientTravelPathMover {
             PathData data = entry.getValue();
 
             Entity entity = level.getEntity(id);
-            if (entity == null || !entity.isAlive() || entity.isSpectator()) {
+            if (!data.doClientTick(entity)) {
                 it.remove();
                 continue;
             }
-
-            if (data.isDone()) {
-                PacketDistributor.sendToServer(new FinishPathPacket(entity.getUUID()));
-                it.remove();
-                continue;
-            }
-
-
-            data.updateLogicalPosition();
-            Vec3 currentDirection = Mods.SABLE.executeIfInstalled(() -> (dir) -> SableCompat.Client.transformToWorld(data.getCurrentTarget(), dir).getSecond(), data.getCurrentDirection());
-            entity.setDeltaMovement(currentDirection);
-            if (data.isClientPlayer())
-                handleEntityDirection(currentDirection);
         }
     }
 
@@ -92,13 +84,7 @@ public class ClientTravelPathMover {
             int id = entry.getKey();
             PathData data = entry.getValue();
 
-            Entity entity = level.getEntity(id);
-            if (entity == null || !entity.isAlive() || entity.isSpectator()) continue;
-            data.handleActionPoint((LivingEntity) entity);
-
-            Vec3 renderPos = renderPos = Mods.SABLE.executeIfInstalled(() -> (pos) -> SableCompat.Client.transformToWorld(pos), data.getRenderPosition(partialTicks));
-
-            entity.moveTo(renderPos.x, renderPos.y, renderPos.z);
+            data.doRenderTick(level.getEntity(id), partialTicks);
         }
     }
 
@@ -118,7 +104,6 @@ public class ClientTravelPathMover {
             }
             data.lastUpdateTick = 5;
             data.currentIndex = segment;
-            data.updateLogicalPosition();
         }
     }
 
@@ -127,72 +112,116 @@ public class ClientTravelPathMover {
     }
 
     public static class PathData {
-        private final List<Vec3> points;
+        private final List<Vec3> pathPoints;
         private final Set<BlockPos> actionPoints;
         private double travelSpeed;
+
         private int currentIndex = 0;
         private int lastUpdateTick = 0;
-
-        private Vec3 currentLogicalPos;
-        private Vec3 previousLogicalPos;
-
+        private Vec3 currentStart;
+        private Vec3 currentEnd;
+        private double totalDistance;
+        private double traveled;
         private float previousPitch = 0;
 
+        private boolean finished = false;
+
         @Getter
-        private boolean clientPlayer;
+        private boolean clientPlayer = false;
 
-        public PathData(List<Vec3> points, Set<BlockPos> actionPoints, double blocksPerSecond, boolean clientPlayer) {
-            this.points = points;
+        public PathData(Vec3 entityPos, List<Vec3> points, Set<BlockPos> actionPoints, double travelSpeed, boolean clientPlayer) {
+            this.pathPoints = points;
             this.actionPoints = actionPoints;
-            this.travelSpeed = blocksPerSecond;
+            this.travelSpeed = travelSpeed;
             this.clientPlayer = clientPlayer;
+            
+            final Vec3 entrancePos = pathPoints.getFirst();
+            Vec3 entranceOffset = Mods.SABLE.executeIfInstalled(() -> (pos) -> SableCompat.Client.transformToSubLevel(entrancePos, pos), entityPos).subtract(entrancePos);
 
-            if (!points.isEmpty()) {
-                this.currentLogicalPos = points.get(0).subtract(0, 0.25, 0);
-                this.previousLogicalPos = this.currentLogicalPos;
-            }
-        }
+            this.currentStart = entrancePos.add(entranceOffset);
+            this.currentEnd = getCurrentTarget();
 
-        public boolean isDone() {
-            return currentIndex >= points.size();
+            this.totalDistance = currentStart.distanceTo(currentEnd);
+            this.traveled = 0;
         }
 
         public Vec3 getCurrentTarget() {
-            if (currentIndex < points.size()) {
-                return points.get(currentIndex).subtract(0, 0.25, 0);
-            }
-            return currentLogicalPos;
+            return pathPoints.get(Math.min(currentIndex, pathPoints.size() - 1));
         }
 
-        public void updateLogicalPosition() {
-            if (isDone()) return;
+        private Vec3 getCurrentDirection() {
+            if (currentEnd.equals(currentStart)) {
+                return Vec3.ZERO;
+            }
+            return currentEnd.subtract(currentStart).normalize();
+        }
 
-            Vec3 target = getCurrentTarget();
-            double distanceToTarget = currentLogicalPos.distanceTo(target);
-            boolean doHalfStep = true;
-            previousLogicalPos = currentLogicalPos;
-            if (distanceToTarget < travelSpeed) {
-                currentLogicalPos = target;
-                currentIndex = (int) (currentIndex + Math.max(1, travelSpeed));
-                if (travelSpeed <= 1) {
-                    doHalfStep = false;
+        private void moveEntity(Entity entity, Vec3 pos) {
+            entity.moveTo(pos.x, pos.y - 0.25, pos.z);
+            entity.setDeltaMovement(Vec3.ZERO);
+        }
+
+        public boolean doClientTick(Entity entity) {
+            if (entity == null || entity.isSpectator() || !entity.isAlive()) {
+                return false;
+            }
+
+            if (traveled >= totalDistance) {
+                currentIndex++;
+                if (currentIndex >= pathPoints.size()) {
+                    finished = true;
+                } else {
+                    currentStart = currentEnd;
+                    currentEnd = getCurrentTarget();
+                    totalDistance = currentStart.distanceTo(currentEnd);
+                    traveled = 0;
                 }
             }
-            if (doHalfStep) {
-                Vec3 direction = target.subtract(currentLogicalPos).normalize().scale(travelSpeed);
-                currentLogicalPos = currentLogicalPos.add(direction);
+
+            if (finished) {
+                PacketDistributor.sendToServer(new FinishPathPacket(entity.getUUID()));
+                Mods.SABLE.executeIfInstalled(() -> () -> SableCompat.stickToSubLevel(entity, null));
+                return false;
             }
+
+            traveled += travelSpeed;
+            Pair<Vec3, Vec3> newPosDir = Pair.of(currentStart.add(direction.scale(traveled)), getCurrentDirection());
+            newPosDir = Mods.SABLE.executeIfInstalled(() -> (pos) -> SableCompat.Client.transformToWorld(newPosDir.getFirst(), newPosDir.getSecond()), newPosDir);
+            Vec3 newPos = newPosDir.getFirst();
+            Vec3 direction = newPosDir.getSecond();
+
+            moveEntity(entity, newPos);
+            if (clientPlayer)
+                handleEntityDirection(direction);
+            
+            return true;
+        }
+        
+        public void doRenderTick(Entity entity, float partialTicks) {
+            if (finished || entity == null || entity.isSpectator() || !entity.isAlive()) {
+                return;
+            }
+            handleActionPoint(entity);
+            
+            Vec3 direction = getCurrentDirection();
+            Vec3 lastClientTickPos = currentStart.add(direction.scale(traveled));
+            Vec3 nextClientTickPos = currentStart.add(direction.scale(traveled + travelSpeed));
+            Vec3 endPos = Mods.SABLE.executeIfInstalled(() -> (pos) -> SableCompat.Client.transformToWorld(pos, true), lastClientTickPos)
+                .lerp(
+                    Mods.SABLE.executeIfInstalled(() -> (pos) -> SableCompat.Client.transformToWorld(pos, false), nextClientTickPos),
+                    partialTicks
+                );
+            moveEntity(entity, endPos);
         }
 
-        public float getPitch() {
-            Vec3 dir = getCurrentDirection();
-            if (dir.equals(Vec3.ZERO) && previousPitch != -1) return previousPitch;
-            float degrees = (float) Math.toDegrees(Math.atan2(-dir.y, Math.sqrt(dir.x * dir.x + dir.z * dir.z)));
-            previousPitch = degrees;
-            return degrees;
+        private static void handleEntityDirection(Vec3 direction) {
+            float yaw = (float) Math.toDegrees(Math.atan2(-direction.x, direction.z));
+            float pitch = (float) Math.toDegrees(Math.atan2(-direction.y, Math.sqrt(direction.x * direction.x + direction.z * direction.z)));
+            DetachedPlayerDirController.get().setDetached(true);
+            DetachedPlayerDirController.get().updateRotation(yaw, pitch);
         }
 
-        public void handleActionPoint(LivingEntity entity) {
+        public void handleActionPoint(Entity entity) {
             BlockPos entityPos = entity.getOnPos();
             if (!actionPoints.contains(entityPos)) return;
             actionPoints.remove(entityPos);
@@ -203,15 +232,11 @@ public class ClientTravelPathMover {
             }
         }
 
-        public Vec3 getCurrentDirection() {
-            if (currentLogicalPos.equals(previousLogicalPos)) {
-                return Vec3.ZERO;
-            }
-            return currentLogicalPos.subtract(previousLogicalPos).normalize();
-        }
-
-        public Vec3 getRenderPosition(float partialTicks) {
-            return previousLogicalPos.lerp(currentLogicalPos, partialTicks);
+        public float getPitch() {
+            Vec3 direction = Mods.SABLE.executeIfInstalled(() -> (dir) -> SableCompat.Client.transformToWorld(currentEnd, dir).getSecond(), getCurrentDirection());
+            if (direction.equals(Vec3.ZERO) && previousPitch != -1) return previousPitch;
+            previousPitch = (float) Math.toDegrees(Math.atan2(-direction.y, Math.sqrt(direction.x * direction.x + direction.z * direction.z)));
+            return previousPitch;
         }
     }
 }

--- a/src/main/java/com/pedrorok/hypertube/core/travel/TravelManager.java
+++ b/src/main/java/com/pedrorok/hypertube/core/travel/TravelManager.java
@@ -95,6 +95,7 @@ public class TravelManager {
         PacketDistributor.sendToPlayersTrackingEntityAndSelf(entity, movePathPacket);
         Vec3 center = pos.getCenter();
         TubeSoundManager.playTubeSuctionSound(entity, center);
+        Mods.SABLE.executeIfInstalled(() -> () -> SableCompat.stickToSubLevel(entity, center));
 
         syncPersistentData(entity);
 
@@ -166,7 +167,9 @@ public class TravelManager {
         lastPosDir = Mods.SABLE.executeIfInstalled(() -> (posDir) -> SableCompat.transformToWorld(level, posDir.getFirst(), posDir.getSecond()), lastPosDir);
         lastBlockPos = lastPosDir.getFirst();
         lastDir = lastPosDir.getSecond();
+        lastBlockPos = lastBlockPos.add(lastDir.scale(0.5));
 
+        Mods.SABLE.executeIfInstalled(() -> () -> SableCompat.stickToSubLevel(entity, null));
         if (!forced) {
             if (level instanceof ServerLevel) {
                 entity.teleportTo((ServerLevel) level, lastBlockPos.x, lastBlockPos.y, lastBlockPos.z, RelativeMovement.ALL, entity.getYRot(), entity.getXRot());

--- a/src/main/java/com/pedrorok/hypertube/core/travel/TravelPathMover.java
+++ b/src/main/java/com/pedrorok/hypertube/core/travel/TravelPathMover.java
@@ -64,15 +64,17 @@ public class TravelPathMover {
         entranceOffset = Mods.SABLE.executeIfInstalled(() -> (dir) -> SableCompat.transformToSubLevel(level, entrancePos, dir).getSecond(), entranceOffset.normalize()).scale(entranceOffset.length());
 
         this.currentStart = entrancePos.add(entranceOffset);
-        this.currentEnd = pathPoints.getFirst().subtract(0, 0.25, 0);
+        this.currentEnd = pathPoints.getFirst();
 
         this.totalDistance = currentStart.distanceTo(currentEnd);
         this.traveled = 0;
 
         this.onFinishCallback = onFinishCallback;
         this.lastDirection = lastDirection;
-        if (lastDirection != null) return;
-        this.lastDirection = pathPoints.getLast().subtract(pathPoints.get(pathPoints.size() - 2)).normalize();
+        if (lastDirection == null) {
+            this.lastDirection = pathPoints.getLast().subtract(pathPoints.get(pathPoints.size() - 2)).normalize();
+        }
+        this.pathPoints.add(pathPoints.getLast().add(this.lastDirection.scale(1)));
     }
 
     public void tickEntity(LivingEntity entity) {
@@ -93,7 +95,7 @@ public class TravelPathMover {
                 return;
             }
             currentStart = currentEnd;
-            currentEnd = pathPoints.get(currentSegment).subtract(0, 0.25, 0);
+            currentEnd = pathPoints.get(currentSegment);
             totalDistance = currentStart.distanceTo(currentEnd);
             traveled = 0;
         }
@@ -115,8 +117,9 @@ public class TravelPathMover {
         Vec3 direction = currentEnd.subtract(currentStart).normalize();
         Vec3 newPos = currentStart.add(direction.scale(traveled));
         newPos = Mods.SABLE.executeIfInstalled(() -> (pos) -> SableCompat.transformToWorld(entity.level(), pos), newPos);
+        direction = Mods.SABLE.executeIfInstalled(() -> (dir) -> SableCompat.transformToWorld(entity.level(), currentStart, dir).getSecond(), direction);
 
-        entity.moveTo(newPos.x, newPos.y, newPos.z);
+        moveEntity(entity, newPos);
         entity.resetFallDistance();
 
         handleEntityDirection(entity, direction);
@@ -141,6 +144,10 @@ public class TravelPathMover {
         entity.setXRot(pitch);
         if (entity.level().isClientSide) return;
         PacketDistributor.sendToPlayersTrackingEntity(entity, EntityTravelDirDataPacket.create(entity));
+    }
+    
+    private void moveEntity(LivingEntity entity, Vec3 pos) {
+        entity.moveTo(pos.x, pos.y - 0.25, pos.z);
     }
 
     public Vec3 getLastDir() {

--- a/src/main/java/com/pedrorok/hypertube/core/travel/TravelPathMover.java
+++ b/src/main/java/com/pedrorok/hypertube/core/travel/TravelPathMover.java
@@ -61,7 +61,7 @@ public class TravelPathMover {
         final Level level = entrance.getLevel();
         final Vec3 entrancePos = entrance.getBlockPos().getCenter();
         Vec3 entranceOffset = entityPos.subtract(Mods.SABLE.executeIfInstalled(() -> (pos) -> SableCompat.transformToWorld(level, pos), entrancePos));
-        entranceOffset = Mods.SABLE.executeIfInstalled(() -> (dir) -> SableCompat.transformToSubLevel(level, entrancePos, dir).getSecond(), entranceOffset.normalize()).scale(entranceOffset.length());
+        entranceOffset = Mods.SABLE.executeIfInstalled(() -> (dir) -> SableCompat.transformToSubLevel(level, entrancePos, Vec3.ZERO, dir).getSecond(), entranceOffset.normalize()).scale(entranceOffset.length());
 
         this.currentStart = entrancePos.add(entranceOffset);
         this.currentEnd = pathPoints.getFirst();

--- a/src/main/java/com/pedrorok/hypertube/mixin/compat/CompatMixinPlugin.java
+++ b/src/main/java/com/pedrorok/hypertube/mixin/compat/CompatMixinPlugin.java
@@ -1,0 +1,57 @@
+package com.pedrorok.hypertube.mixin.compat;
+
+import com.pedrorok.hypertube.core.compat.Mods;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class CompatMixinPlugin implements IMixinConfigPlugin {
+    private static final Map<String, Mods> MOD_FOLDERS = Map.of(
+        // mixin.compat."folder", Mods.VALUE
+        "sable", Mods.SABLE
+    );
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.contains(".mixin.compat.")) {
+            String[] parts = mixinClassName.split("\\.mixin.compat\\.", 2)[1].split("\\."); // split uses regex, so have to escape all periods
+            String path = "";
+            for (String s : parts) {
+                path += s;
+                Mods mod = MOD_FOLDERS.getOrDefault(path, null);
+                if (mod != null && mod.isLoaded()) {
+                    return true;
+                }
+                path += ".";
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void onLoad(String mixinPackage) {}
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+}

--- a/src/main/java/com/pedrorok/hypertube/mixin/compat/sable/EntityMixin.java
+++ b/src/main/java/com/pedrorok/hypertube/mixin/compat/sable/EntityMixin.java
@@ -1,0 +1,35 @@
+package com.pedrorok.hypertube.mixin.compat.sable;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.pedrorok.hypertube.core.compat.sable.EntityForceTracking;
+import com.pedrorok.hypertube.HypertubeMod;
+import dev.ryanhcode.sable.sublevel.SubLevel;
+import lombok.Setter;
+import net.minecraft.world.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = Entity.class, priority = 1200)
+public abstract class EntityMixin implements EntityForceTracking {
+    @Unique
+    private SubLevel createHypertube$forceTrackSubLevel = null;
+
+    @Unique
+    @Override
+    public void createHypertube$setForceTrackSubLevel(SubLevel subLevel) {
+        this.createHypertube$forceTrackSubLevel = subLevel;
+    }
+
+    /**
+     * @return the sub-level the entity is standing on or locked to
+     */
+    @ModifyReturnValue(
+        method = "sable$getTrackingSubLevel()Ldev/ryanhcode/sable/sublevel/SubLevel;", 
+        remap = false,
+        at = @At("RETURN")
+    )
+    public SubLevel createHypertube$getTrackingSubLevel(SubLevel original) {
+        return this.createHypertube$forceTrackSubLevel != null ? this.createHypertube$forceTrackSubLevel : original;
+    }
+}

--- a/src/main/resources/compat.mixins.json
+++ b/src/main/resources/compat.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": false,
+  "minVersion": "0.8",
+  "package": "com.pedrorok.hypertube.mixin.compat",
+  "refmap": "compat.refmap.json",
+  "plugin": "com.pedrorok.hypertube.mixin.compat.CompatMixinPlugin",
+  "compatibilityLevel": "JAVA_8",
+  "client": [
+    "sable.EntityMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
Improves #155
Entities now track the sublevel that the Hypertube is on, meaning Sable will move and rotate them along with the sublevel.
Entities now also properly account for pitch and yaw provided by the Hypertube's sublevel, rotating to stay oriented inside the tube.

I ended up having to rewrite a large portion of the ClientTravelPathMover due to some desync and janky movements I was getting with the previous implementation.


https://github.com/user-attachments/assets/af610be0-bf4f-41b0-a427-0ff866635c44
